### PR TITLE
Fixing edit url, getting 404 with edit/ instead of edit

### DIFF
--- a/lib/delhivery/services/package_service.rb
+++ b/lib/delhivery/services/package_service.rb
@@ -32,7 +32,7 @@ module Delhivery
       end
 
       def edit_path
-        "/api/p/edit/"
+        "/api/p/edit"
       end
     end
   end


### PR DESCRIPTION
The existing url with succeeding / gives 404 for edit. Fixing it.